### PR TITLE
ISUCON本のAMI（Ubuntu 22.04 LTS）対応

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,10 @@
 
 [Pixiv 社内 ISUCON 2016](https://github.com/catatsuy/private-isu) の Python 版実装です。
 
-Python で ISUCON 2016 に参加する予定の人が、 Pixiv 社内 ISUCON を使って練習するときの
+Python で ISUCON に参加する予定の人が、 Pixiv 社内 ISUCON を使って練習するときの
 参照実装として使えるようにと考えています。
 
+ISUCON本を題材にした練習にも利用できます。
 
 ## セットアップ
 
@@ -15,24 +16,32 @@ AMI からのスタートでも、 リポジトリからのスタートでも、
 
 ```console
 $ cd private_isu/webapp
-$ git clone https://github.com/methane/pixiv-isucon2016-python python
+$ git clone https://github.com/netmarkjp/pixiv-isucon2016-python python
 $ cd python
 ```
 
+## 実行環境の準備の準備
+
+private-isuのAMI(Ubuntu 22.04 LTS)の場合は以下を実行しておきます。
+
+```console
+$ sudo apt update
+$ sudo apt -y install python3.10-venv
+$ sudo apt -y install python3.10-dev default-libmysqlclient-dev build-essential
+```
 
 ### 実行環境の準備
 
-pyenv 等を利用して Python 3.5.2 を準備しておいてください。
+pyenv 等を利用して Python 3.10.6 を準備しておいてください。
+private-isuのAMI(Ubuntu 22.04 LTS)の場合はシステムの Python 3.10 を利用できます。
 以下の例では venv を用意していますが、 pyenv を使ってる場合は venv を利用せず直接インストールしても大丈夫です。
-
 
 ```console
 $ python3 -V
-Python 3.5.2
+Python 3.10.6
 $ python3 -m venv venv
 $ venv/bin/pip install -r requirements.freeze
 ```
-
 
 ## デバッグモードで実行
 
@@ -40,3 +49,15 @@ $ venv/bin/pip install -r requirements.freeze
 $ FLASK_APP=app.py venv/bin/flask run -p 8080 --debugger
 ```
 
+
+## デーモンとして設定
+
+```console
+$ venv/bin/pip install gunicorn==20.1.0
+$ sudo cp isu-python.service /etc/systemd/system/.
+$ sudo systemctl daemon-reload
+$ sudo systemctl disable isu-ruby
+$ sudo systemctl stop isu-ruby
+$ sudo systemctl start isu-python
+$ sudo systemctl enable isu-python
+```

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ AMI からのスタートでも、 リポジトリからのスタートでも、
 
 ```console
 $ cd private_isu/webapp
-$ git clone https://github.com/netmarkjp/pixiv-isucon2016-python python
+$ git clone https://github.com/methane/pixiv-isucon2016-python python
 $ cd python
 ```
 

--- a/app.py
+++ b/app.py
@@ -35,7 +35,6 @@ def config():
             _config['db']['passwd'] = password
     return _config
 
-
 _db = None
 
 def db():
@@ -166,12 +165,13 @@ def image_url(post):
     return "/image/%s%s" % (post['id'], ext)
 
 # http://flask.pocoo.org/snippets/28/
-from jinja2 import evalcontextfilter, Markup, escape
+from jinja2 import pass_eval_context
+from markupsafe import Markup, escape
 
 _paragraph_re = re.compile(r'(?:\r\n|\r|\n){2,}')
 
 @app.template_filter()
-@evalcontextfilter
+@pass_eval_context
 def nl2br(eval_ctx, value):
     result = u'\n\n'.join(u'<p>%s</p>' % p.replace('\n', '<br>\n') \
         for p in _paragraph_re.split(escape(value)))

--- a/isu-python.service
+++ b/isu-python.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=isu-python
+After=syslog.target
+
+[Service]
+WorkingDirectory=/home/isucon/private_isu/webapp/python
+EnvironmentFile=/home/isucon/env.sh
+PIDFile=/home/isucon/private_isu/webapp/python/server.pid
+
+User=isucon
+Group=isucon
+ExecStart=/home/isucon/private_isu/webapp/python/venv/bin/gunicorn app:app -b 0.0.0.0:8080 --log-file - --access-logfile -
+ExecStop=/bin/kill -s QUIT $MAINPID
+
+[Install]
+WantedBy=multi-user.target

--- a/pymc_session.py
+++ b/pymc_session.py
@@ -32,7 +32,7 @@ class SessionInterface(SessionInterface):
         return timedelta(days=1)
 
     def open_session(self, app, request):
-        sid = request.cookies.get(app.session_cookie_name)
+        sid = request.cookies.get(app.config["SESSION_COOKIE_NAME"])
         if not sid:
             sid = self.generate_sid()
             return Session(sid=sid, new=True)
@@ -47,7 +47,7 @@ class SessionInterface(SessionInterface):
         if not session:
             self.memcache.delete(self.prefix + session.sid)
             if session.modified:
-                response.delete_cookie(app.session_cookie_name,
+                response.delete_cookie(app.config["SESSION_COOKIE_NAME"],
                                        domain=domain)
             return
         memcache_exp = self.get_memcache_expiration_time(app, session)
@@ -55,6 +55,6 @@ class SessionInterface(SessionInterface):
         val = json.dumps(dict(session))
         self.memcache.set(self.prefix + session.sid, val,
                           int(memcache_exp.total_seconds()))
-        response.set_cookie(app.session_cookie_name, session.sid,
+        response.set_cookie(app.config["SESSION_COOKIE_NAME"], session.sid,
                             expires=cookie_exp, httponly=True,
                             domain=domain)

--- a/requirements.freeze
+++ b/requirements.freeze
@@ -4,5 +4,5 @@ itsdangerous==2.1.2
 Jinja2==3.1.2
 MarkupSafe==2.1.1
 mysqlclient==2.1.1
-pymemcache==4.0.0
+pymemcache==3.5.2
 Werkzeug==2.2.2

--- a/requirements.freeze
+++ b/requirements.freeze
@@ -1,9 +1,8 @@
-click==6.6
-Flask==0.11.1
-itsdangerous==0.24
-Jinja2==2.8
-MarkupSafe==0.23
-mysqlclient==1.3.7
-pymemcache==1.3.6
-six==1.10.0
-Werkzeug==0.11.10
+click==8.1.3
+Flask==2.2.2
+itsdangerous==2.1.2
+Jinja2==3.1.2
+MarkupSafe==2.1.1
+mysqlclient==2.1.1
+pymemcache==4.0.0
+Werkzeug==2.2.2

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -10,9 +10,7 @@
       {% include 'header.html' %}
       {% block body %}{% endblock %}
     </div>
-    <script src="/js/jquery-2.2.0.js"></script>
-    <script src="/js/jquery.timeago.js"></script>
-    <script src="/js/jquery.timeago.ja.js"></script>
+    <script src="/js/timeago.min.js"></script>
     <script src="/js/main.js"></script>
   </body>
 </html>


### PR DESCRIPTION
ISUCON本の環境（＝最新AMI）で簡単に気持ちよく動作させられるように、Pythonバージョンやライブラリを更新しました。
最新化に興味ありましたら、ぜひ取り込んでいただきたく。

flaskコマンドで起動してベンチマークをかけたところsegfaultしたので、gunicorn用のunitファイルを同梱しています。
（ `isu-python.service` ）